### PR TITLE
Add Eureka Server Configuration and Enable Eureka Server

### DIFF
--- a/src/main/java/org/example/discoveryserver/DiscoveryServerApplication.java
+++ b/src/main/java/org/example/discoveryserver/DiscoveryServerApplication.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
 
 @SpringBootApplication
+@EnableEurekaServer
 public class DiscoveryServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+# Eureka Configuration
+eureka.instance.hostname=localhost
+eureka.client.register-with-eureka=false
+eureka.client.fetch-registry=false
+
+# Server Port
+server.port=8761


### PR DESCRIPTION
### Description:
This pull request introduces the following changes to the codebase:

- Added `@EnableEurekaServer` annotation to the `DiscoveryServerApplication` class, enabling it to function as a Eureka server.
- Modified `application.properties` to configure Eureka with specific properties:
  - `eureka.instance.hostname=localhost`: Sets the hostname for the Eureka server to localhost.
  - `eureka.client.register-with-eureka=false`: Disables the registration of this Eureka server with itself.
  - `eureka.client.fetch-registry=false`: Disables fetching the registry information from other Eureka servers.
  - `server.port=8761`: Sets the server port to 8761 for Eureka.

### Purpose:
The purpose of this pull request is to configure the application as a Eureka server, providing service discovery functionality for microservices in the system.
