### PR TITLE
Add Spring Security Configuration for Eureka Server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/src/main/java/org/example/discoveryserver/config/SecurityConfig.java
+++ b/src/main/java/org/example/discoveryserver/config/SecurityConfig.java
@@ -1,0 +1,58 @@
+package org.example.discoveryserver.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+  @Value("${spring.security.user.name}")
+  private String username;
+
+  @Value("${spring.security.user.password}")
+  private String password;
+
+  @Value("${spring.security.user.roles}")
+  private String roles;
+
+  @Bean
+  public InMemoryUserDetailsManager userDetailsService(PasswordEncoder passwordEncoder) {
+    UserDetails user = User.withUsername(username)
+            .password(passwordEncoder.encode(password))
+            .roles(roles)
+            .build();
+
+    return new InMemoryUserDetailsManager(user);
+  }
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    return http
+            .csrf(AbstractHttpConfigurer::disable)
+            .authorizeHttpRequests(request -> {
+                      request.requestMatchers("/eureka/**")
+                              .permitAll();
+                      request.anyRequest()
+                              .authenticated();
+                    }
+            )
+            .httpBasic(Customizer.withDefaults())
+            .build();
+  }
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,8 @@ eureka.client.fetch-registry=false
 
 # Server Port
 server.port=8761
+
+# Eureka Basic Authentication Credentials
+spring.security.user.name=root
+spring.security.user.password=root
+spring.security.user.roles=USER


### PR DESCRIPTION
### Description:
This pull request introduces the following changes to the codebase:

### Changes:
- Added `spring-boot-starter-security` dependency to the `pom.xml`.
- Add `SecurityConfig` class in the `config` package to configure Spring Security for the Eureka Server.
- The `SecurityConfig` class includes:
  - Definition of basic authentication credentials for Eureka (`username: root`, `password: root`, `roles: USER`).
  - Configuration to permit all requests to `/eureka/**` and require authentication for other requests.
  - Use of `PasswordEncoderFactories.createDelegatingPasswordEncoder()` for password encoding.

### Purpose:
The purpose of this pull request is to enhance the security of the Eureka Server by introducing basic authentication. This ensures that access to Eureka endpoints is restricted to authenticated users, improving overall system security.
