### PR TITLE
Add Docker Configuration for Discovery Server

### DIFF
--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -1,0 +1,5 @@
+# Server Port
+server.port=8761
+
+# Zipkin Configuration
+management.zipkin.tracing.endpoint=http://zipkin:9411


### PR DESCRIPTION
### Description:
This pull request introduces Docker-specific configuration properties for the Discovery Server service.

### Changes:
- **application-docker.properties:** Added a new properties file in the `src/main/resources` directory to configure the application for Docker environments.
- **Server Port:** Configures the server port to `8761` using the `server.port` property.
- **Zipkin Tracing Endpoint:** Sets the Zipkin tracing endpoint to `http://zipkin:9411` using the `management.zipkin.tracing.endpoint` property.

### Purpose:
The purpose of this pull request is to introduce Docker-specific configuration properties for the Discovery Server service. These properties are intended to be used when running the application in a Docker container environment. The configurations include setting the server port and the Zipkin tracing endpoint specific to the Docker environment. This pull request ensures that the Discovery Server service can properly run and connect to the Zipkin service when deployed in a Docker-based infrastructure.