### PR TITLE
Add Prometheus Metrics Support to Discovery Server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
 			<groupId>io.micrometer</groupId>
 			<artifactId>micrometer-tracing-bridge-brave</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,3 +17,6 @@ spring.security.user.roles=USER
 # Zipkin Configuration
 management.zipkin.tracing.endpoint=http://localhost:9411/api/v2/spans
 management.tracing.sampling.probability=1.0
+
+# Actuator Prometheus Endpoint
+management.endpoints.web.exposure.include=prometheus


### PR DESCRIPTION
### Description:
This pull request introduces changes to enable Prometheus metrics collection and monitoring in the Discovery Server microservice.

### Changes:
- **Add Prometheus Metrics Support:** Added dependency for `micrometer-registry-prometheus` to enable Prometheus metrics collection.
- **Configure Prometheus Endpoint:** Configured Prometheus actuator endpoint in `application.properties` by adding `management.endpoints.web.exposure.include=prometheus`.

### Purpose:
The purpose of this pull request is to integrate the Discovery Server microservice with Prometheus for monitoring and collecting metrics. By adding the Prometheus registry and exposing the Prometheus actuator endpoint, the Discovery Server can be scraped by Prometheus, allowing for visualization and analysis of various metrics such as request rates, response times, and system resource utilization. This enhancement improves observability and aids in monitoring the health and performance of the Discovery Server.