### PR TITLE
Fix Zipkin Tracing Endpoint Configuration

### DIFF
--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -2,4 +2,4 @@
 server.port=8761
 
 # Zipkin Configuration
-management.zipkin.tracing.endpoint=http://zipkin:9411
+management.zipkin.tracing.endpoint=http://zipkin:9411/api/v2/spans


### PR DESCRIPTION
### Description:
This pull request fixes the configuration for the Zipkin tracing endpoint in the Discovery Server when running in a Docker environment.

### Changes:
- **Fix Zipkin Tracing Endpoint:** Updated the `management.zipkin.tracing.endpoint` property in the `application-docker.properties` file to include the correct endpoint path `/api/v2/spans` for Zipkin.

### Purpose:
The purpose of this pull request is to ensure that the Discovery Server can correctly send tracing data to the Zipkin server when running in a Docker environment. The previous configuration was missing the `/api/v2/spans` path, which is required by Zipkin to properly receive and process the trace data. By updating this property, the Discovery Server will be able to correctly send tracing data, enabling distributed tracing and monitoring of requests across the microservices.